### PR TITLE
fix gcc linker error and compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ NBI += memcpy memmove memcmp
 
 # minimal requirement on x86_64: -march=nehalem
 # minimal requirement on aarch64: -march=armv8-a+crc
-FLG += -march=$(ARCH) -mtune=$(TUNE)
+FLG += -march=$(ARCH) -mtune=$(TUNE) -msse4.2
 FLG += -pthread -Wall -Wextra -Wshadow
 FLG += $(addprefix -fno-builtin-,$(NBI))
 FLG += $(OPT)


### PR DESCRIPTION
- add -msse4.2 for _mm_crc32_* or gcc wont link the binary
- guard the use of #pragma nounroll which is clang only
- fix the use of a static function in non static call site